### PR TITLE
Fix #9 by adding a FileNotFoundError exception handling

### DIFF
--- a/baboossh/ext_dir/payload_gather.py
+++ b/baboossh/ext_dir/payload_gather.py
@@ -256,14 +256,18 @@ class BaboosshExt(object,metaclass=ExtStr):
         files = []
         ret = []
         chan = self.connection.transport.open_channel("session",timeout=3)
-        filelist = self.sftp.listdir_attr(".ssh")
-        for file in filelist:
-            if file.st_size == 0:
-                continue
-            if "rsa" in file.filename or "key" in file.filename or "p12" in file.filename or "dsa" in file.filename:
-                files.append(file.filename)
-        for keyfile in files:
-            c = self.getKeyToCreds(keyfile)
+        try:
+            filelist = self.sftp.listdir_attr(".ssh")
+            for file in filelist:
+                if file.st_size == 0:
+                    continue
+                if "rsa" in file.filename or "key" in file.filename or "p12" in file.filename or "dsa" in file.filename:
+                    files.append(file.filename)
+            for keyfile in files:
+                c = self.getKeyToCreds(keyfile)
+        except FileNotFoundError:
+            # TODO : log somehow the failure
+            pass
 
     def getKeyToCreds(self,keyfile,basePath=".ssh"):
         if basePath != ".":


### PR DESCRIPTION
# Description

A simple exception handling for *FileNotFoundError* has been added in order to avoid a fail in case of the *.ssh* folder does not exist.

Fixes #9 

# Proof
* Targeted user's workspace content
```bash
$ ls -a
.   .asoundrc	   .bash_logout  .cache   .dbus    .dmrc      Downloads  .gksu.lock  .gnupg	     .gtkrc-2.0     .lesshst  Music	.profile  .python_history	     Templates	.Xauthority
..  .bash_history  .bashrc	 .config  Desktop  Documents  .face	 .gnome      .gtk-bookmarks  .ICEauthority  .local    Pictures	Public	  .sudo_as_admin_successful  Videos	.xsession-errors
```
* Gather payload results
```python
  %%%%%/      %%%     %%%%%.      .%%/     %%     %/   /%%%/   ,%%%/  *%%    %%
  %%   %%*   %% %%    %%   %%  %*       % %    /@*  % %%      %%      *%%    %% 
  %%%%%%    %%, %%%   %%%%%%  %    @@@@  %    /@@@  /  %%%%    %%%%   *%%%%%%%% 
  %%   %%% %%%%%%%%,  %%   %%(%          %%         %     %%%     %%% *%%    %% 
  %%%%%%  ,%%     %%  %%%%%%   %%      ,%   %#   %%   %%%%%.  %%%%%.  *%%    %%

Welcome to BabooSSH v1.1.3. To start, use "help -v" to list commands.
[default]> endpoint add 192.168.1.169
Endpoint 192.168.1.169:22 added.
[default]> user add testuser
User testuser added.
[default]> creds add password testuser
Credentials #1 added.
[default]> connect
Connecting to testuser:#1@192.168.1.169:22... OK
1/1 working.
[default]> set payload gather 
payload => gather
[default](gather)> run
Connection to testuser:#1@192.168.1.169:22 already open. > OK
Starting gathering...
From SSH user config
From history files
	 -.python_history
From user keys
From known_hosts
Done !
Users :

Creds :

Endpoints :
[default](gather)> 

```